### PR TITLE
Update zsh extension autocomplete

### DIFF
--- a/Setting up environment/README.md
+++ b/Setting up environment/README.md
@@ -9,7 +9,7 @@
 
   - #### Extensions
 
-    - Autocomplete
+    - [zsh-autosuggestions(Auto Complete)](https://github.com/zsh-users/zsh-autosuggestions)
 
     - git
 


### PR DESCRIPTION
Previously it was autocomplete but zsh does not have any plugin by that name so i changed it to the correct one and provided the link to repository too.